### PR TITLE
README: add clipboard tool dependency (#886)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you are experiencing issues, please make sure you have the latest versions.
 External Requirements:
 - Basic utils: `git`, `make`, `unzip`, C Compiler (`gcc`)
 - [ripgrep](https://github.com/BurntSushi/ripgrep#installation)
+- Clipboard tool (xclip/xsel/win32yank or other depending on platform)
 - A [Nerd Font](https://www.nerdfonts.com/): optional, provides various icons
   - if you have it set `vim.g.have_nerd_font` in `init.lua` to true
 - Language Setup:
@@ -182,7 +183,7 @@ wsl --install
 wsl
 sudo add-apt-repository ppa:neovim-ppa/unstable -y
 sudo apt update
-sudo apt install make gcc ripgrep unzip neovim
+sudo apt install make gcc ripgrep unzip git xclip neovim
 ```
 </details>
 
@@ -192,14 +193,14 @@ sudo apt install make gcc ripgrep unzip neovim
 ```
 sudo add-apt-repository ppa:neovim-ppa/unstable -y
 sudo apt update
-sudo apt install make gcc ripgrep unzip git neovim
+sudo apt install make gcc ripgrep unzip git xclip neovim
 ```
 </details>
 <details><summary>Debian Install Steps</summary>
 
 ```
 sudo apt update
-sudo apt install make gcc ripgrep unzip git curl
+sudo apt install make gcc ripgrep unzip git xclip curl
 
 # Now we install nvim
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz


### PR DESCRIPTION
Fixes: #884
Neovim requires an external tool for proper system clipboard integration. Some systems install this already by default:
- on Fedora xsel is already installed by default
- on Windows using the choko install the win32yank is alredy installed This is not installed by default on ubuntu or debian so adding that to the dependencies list and to the install instructions snippets.

***************************************************************************
**NOTE**
Please verify that the `base repository` above has the intended destination!
Github by default opens Pull Requests against the parent of a forked repository.
If this is your personal fork and you didn't intend to open a PR for contribution
to the original project then adjust the `base repository` accordingly.
**************************************************************************

